### PR TITLE
use ubuntu 15.04 baseimage and skip brightbox ruby

### DIFF
--- a/simple/Dockerfile
+++ b/simple/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:14.04
+FROM ubuntu:15.04
 MAINTAINER Linki <linki+docker.com@posteo.de>
 
 # update the package list
@@ -24,15 +24,6 @@ RUN ln -s nodejs /usr/bin/node
 
 # install git in order to checkout gems defined by git urls
 RUN apt-get -y install git-core
-
-# install ruby 2.1
-#
-# the following installs ruby 2.1 via the apt package manager. unfortunately,
-# the default packages still only contain ruby 1.9, so we use brightbox's one.
-#
-RUN apt-get install -y software-properties-common python-software-properties
-RUN apt-add-repository -y ppa:brightbox/ruby-ng
-RUN apt-get update
 
 # install ruby 2.1 with development extensions
 RUN apt-get install -y ruby2.1 ruby2.1-dev


### PR DESCRIPTION
uses ubuntu 15.04 as base distro which apparently has ruby 2.1 packages
